### PR TITLE
Add support for 'template' in 'user_files'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,19 @@ This depends on the vim-formula to be installed.
 ---------------
 
 Permits the abitrary management of files. See pillar.example for configuration details.
+
+Overriding default values
+=========================
+
+In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
+
+```yaml
+users:
+  myuser:
+    # stuff
+
+users-formula:
+  lookup:
+    root_group: toor
+    shell: '/bin/zsh'
+```

--- a/README.rst
+++ b/README.rst
@@ -55,9 +55,9 @@ Permits the abitrary management of files. See pillar.example for configuration d
 Overriding default values
 =========================
 
-In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
+In order to separate actual user account definitions from configuration the pillar ``users-formula`` was introduced:
 
-.. code-bock:: yaml
+.. code-block:: yaml
 
     users:
       myuser:

--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,12 @@ Overriding default values
 
 In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
 
-```yaml
-users:
-  myuser:
-    # stuff
+.. code-bock:: yaml
+    users:
+      myuser:
+        # stuff
 
-users-formula:
-  lookup:
-    root_group: toor
-    shell: '/bin/zsh'
-```
+    users-formula:
+      lookup:
+        root_group: toor
+        shell: '/bin/zsh'

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ Overriding default values
 In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
 
 .. code-bock:: yaml
+
     users:
       myuser:
         # stuff

--- a/pillar.example
+++ b/pillar.example
@@ -11,6 +11,7 @@ users:
     # WARNING: If 'empty_password' is set to True, the 'password' statement
     # will be ignored by enabling password-less login for the user.
     empty_password: False
+    hash_password: False
     system: False
     home: /custom/buser
     homedir_owner: buser

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,7 @@
+users-formula:
+  lookup:  # override the defauls in map.jinja
+    root_group: root
+
 users:
   ## Minimal required pillar values
   auser:

--- a/pillar.example
+++ b/pillar.example
@@ -73,6 +73,8 @@ users:
     # than inline in pillar, this works.
     ssh_auth_sources:
       - salt://keys/buser.id_rsa.pub
+    ssh_auth_sources.absent:
+      - salt://keys/deleteduser.id_rsa.pub # PUBLICKEY_FILE_TO_BE_REMOVED
     # Manage the ~/.ssh/config file
     ssh_known_hosts:
       importanthost:

--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,8 @@ users:
     # will be ignored by enabling password-less login for the user.
     empty_password: False
     home: /custom/buser
+    homedir_owner: buser
+    homedir_group: primarygroup
     createhome: True
     roomnumber: "A-1"
     workphone: "(555) 555-5555"

--- a/pillar.example
+++ b/pillar.example
@@ -116,6 +116,7 @@ users:
       # should be a salt fileserver path either with or without 'salt://'
       # if not present, it defaults to 'salt://users/files/user/<username>
       source: users/files/default
+      template: jinja
 
   ## Absent user
   cuser:

--- a/pillar.example
+++ b/pillar.example
@@ -119,6 +119,11 @@ users:
       # should be a salt fileserver path either with or without 'salt://'
       # if not present, it defaults to 'salt://users/files/user/<username>
       source: users/files/default
+      # You can specify octal mode for files and symlinks that will be copied. Since version 2016.11.0
+      # it's possible to use 'keep' for file_mode, to preserve file original mode, thus you can save
+      # execution bit for example.
+      file_mode: keep
+      sym_mode: 640
 
   ## Absent user
   cuser:

--- a/pillar.example
+++ b/pillar.example
@@ -96,7 +96,7 @@ users:
     gitconfig:
       user.name: B User
       user.email: buser@example.com
-      url."https://".insteadOf: "git://"
+      "url.https://.insteadOf": "git://"
 
     google_2fa: True
     google_auth:

--- a/users/bashrc.sls
+++ b/users/bashrc.sls
@@ -21,7 +21,8 @@ users_{{ name }}_user_bashrc:
     - user: {{ name }}
     - group: {{ user_group }}
     - mode: 644
-    - source: 
+    - template: jinja
+    - source:
       - salt://users/files/bashrc/{{ name }}/bashrc
       - salt://users/files/bashrc/bashrc
 {% endif %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -430,12 +430,20 @@ users_googleauth-{{ svc }}-{{ name }}:
 {%- endfor %}
 {%- endif %}
 
+#
+# if not salt['cmd.has_exec']('git')
+# fails even if git is installed
+#
+# this doesn't work (Salt bug), therefore need to run state.apply twice
+#include:
+#  - users
+#
+#git:
+#  pkg.installed:
+#    - require_in:
+#      - sls: users
+#
 {% if 'gitconfig' in user %}
-{% if not salt['cmd.has_exec']('git') %}
-skip_{{ name }}_gitconfig_since_git_not_installed:
-  test.fail_without_changes:
-    - name: "Git configuration for user {{ name }} has been skipped because Git is not installed."
-{% else %}
 {% for key, value in user['gitconfig'].items() %}
 users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
   {% if grains['saltversioninfo'] >= (2015, 8, 0, 0) %}
@@ -452,7 +460,6 @@ users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
     - is_global: True
     {% endif %}
 {% endfor %}
-{% endif %}
 {% endif %}
 
 {% endfor %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -479,7 +479,7 @@ users_{{ users.sudoers_dir }}/{{ name }}:
 {% for user in pillar.get('absent_users', []) %}
 users_absent_user_2_{{ user }}:
   user.absent:
-    - name: {{ name }}
+    - name: {{ user }}
 users_2_{{ users.sudoers_dir }}/{{ user }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ user }}

--- a/users/init.sls
+++ b/users/init.sls
@@ -101,6 +101,8 @@ users_{{ name }}_user:
     {% endif -%}
     {% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
     - gid: {{ user['prime_group']['gid'] }}
+    {% elif 'prime_group' in user and 'name' in user['prime_group'] %}
+    - gid: {{ user['prime_group']['name'] }}
     {% else -%}
     - gid_from_name: True
     {% endif -%}

--- a/users/init.sls
+++ b/users/init.sls
@@ -280,7 +280,7 @@ users_ssh_auth_source_{{ name }}_{{ loop.index0 }}:
 
 {% if 'ssh_auth_sources.absent' in user %}
 {% for pubkey_file in user['ssh_auth_sources.absent'] %}
-users_ssh_auth_source_{{ name }}_{{ loop.index0 }}:
+users_ssh_auth_source_delete_{{ name }}_{{ loop.index0 }}:
   ssh_auth.absent:
     - user: {{ name }}
     - source: {{ pubkey_file }}

--- a/users/init.sls
+++ b/users/init.sls
@@ -93,6 +93,9 @@ users_{{ name }}_user:
     {% if 'enforce_password' in user -%}
     - enforce_password: {{ user['enforce_password'] }}
     {% endif -%}
+    {% if 'hash_password' in user -%}
+    - hash_password: {{ user['hash_password'] }}
+    {% endif -%}
     {% if user.get('system', False) -%}
     - system: True
     {% endif -%}

--- a/users/init.sls
+++ b/users/init.sls
@@ -59,8 +59,8 @@ users_{{ name }}_user:
   {% if user.get('createhome', True) %}
   file.directory:
     - name: {{ home }}
-    - user: {{ user.get('user_dir_user', name) }}
-    - group: {{ user.get('user_dir_group', user_group) }}
+    - user: {{ user.get('homedir_owner', name) }}
+    - group: {{ user.get('homedir_group', user_group) }}
     - mode: {{ user.get('user_dir_mode', '0750') }}
     - require:
       - user: users_{{ name }}_user

--- a/users/init.sls
+++ b/users/init.sls
@@ -59,8 +59,8 @@ users_{{ name }}_user:
   {% if user.get('createhome', True) %}
   file.directory:
     - name: {{ home }}
-    - user: {{ name }}
-    - group: {{ user_group }}
+    - user: {{ user.get('user_dir_user', name) }}
+    - group: {{ user.get('user_dir_group', user_group) }}
     - mode: {{ user.get('user_dir_mode', '0750') }}
     - require:
       - user: users_{{ name }}_user

--- a/users/init.sls
+++ b/users/init.sls
@@ -278,6 +278,18 @@ users_ssh_auth_source_{{ name }}_{{ loop.index0 }}:
 {% endfor %}
 {% endif %}
 
+{% if 'ssh_auth_sources.absent' in user %}
+{% for pubkey_file in user['ssh_auth_sources.absent'] %}
+users_ssh_auth_source_{{ name }}_{{ loop.index0 }}:
+  ssh_auth.absent:
+    - user: {{ name }}
+    - source: {{ pubkey_file }}
+    - require:
+        - file: users_{{ name }}_user
+        - user: users_{{ name }}_user
+{% endfor %}
+{% endif %}
+
 {% if 'ssh_auth.absent' in user %}
 {% for auth in user['ssh_auth.absent'] %}
 users_ssh_auth_delete_{{ name }}_{{ loop.index0 }}:

--- a/users/init.sls
+++ b/users/init.sls
@@ -354,12 +354,13 @@ users_ssh_known_hosts_delete_{{ name }}_{{ loop.index0 }}:
 {% endfor %}
 {% endif %}
 
+{% set sudoers_d_filename = name|replace('.','_') %}
 {% if 'sudouser' in user and user['sudouser'] %}
 
 users_sudoer-{{ name }}:
   file.managed:
     - replace: False
-    - name: {{ users.sudoers_dir }}/{{ name }}
+    - name: {{ users.sudoers_dir }}/{{ sudoers_d_filename }}
     - user: root
     - group: {{ users.root_group }}
     - mode: '0440'
@@ -398,7 +399,7 @@ users_sudoer-{{ name }}:
 users_{{ users.sudoers_dir }}/{{ name }}:
   file.managed:
     - replace: True
-    - name: {{ users.sudoers_dir }}/{{ name }}
+    - name: {{ users.sudoers_dir }}/{{ sudoers_d_filename }}
     - contents: |
       {%- if 'sudo_defaults' in user %}
       {%- for entry in user['sudo_defaults'] %}
@@ -419,14 +420,14 @@ users_{{ users.sudoers_dir }}/{{ name }}:
       - file: users_sudoer-defaults
       - file: users_sudoer-{{ name }}
   cmd.wait:
-    - name: visudo -cf {{ users.sudoers_dir }}/{{ name }} || ( rm -rvf {{ users.sudoers_dir }}/{{ name }}; exit 1 )
+    - name: visudo -cf {{ users.sudoers_dir }}/{{ sudoers_d_filename }} || ( rm -rvf {{ users.sudoers_dir }}/{{ sudoers_d_filename }}; exit 1 )
     - watch:
-      - file: {{ users.sudoers_dir }}/{{ name }}
+      - file: {{ users.sudoers_dir }}/{{ sudoers_d_filename }}
 {% endif %}
 {% else %}
-users_{{ users.sudoers_dir }}/{{ name }}:
+users_{{ users.sudoers_dir }}/{{ sudoers_d_filename }}:
   file.absent:
-    - name: {{ users.sudoers_dir }}/{{ name }}
+    - name: {{ users.sudoers_dir }}/{{ sudoers_d_filename }}
 {% endif %}
 
 {%- if 'google_auth' in user %}

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -33,6 +33,17 @@
     'sudo_package': 'sudo',
     'googleauth_package': 'pam_google_authenticator',
   },
+  'Solaris': {
+    'sudoers_dir': '/opt/local/etc/sudoers.d',
+    'sudoers_file': '/opt/local/etc/sudoers',
+    'googleauth_dir': '/opt/local/etc/google_authenticator.d',
+    'root_group': 'root',
+    'shell': '/bin/bash',
+    'visudo_shell': '/bin/bash',
+    'bash_package': 'bash',
+    'sudo_package': 'sudo',
+    'googleauth_package': 'libpam-google-authenticator',
+  },
   'default': {
     'sudoers_dir': '/etc/sudoers.d',
     'sudoers_file': '/etc/sudoers',

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -44,4 +44,4 @@
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
   },
-}, merge=salt['pillar.get']('users:lookup')) %}
+}, merge=salt['pillar.get']('users-formula:lookup')) %}

--- a/users/profile.sls
+++ b/users/profile.sls
@@ -21,6 +21,7 @@ users_{{ name }}_user_profile:
     - user: {{ name }}
     - group: {{ user_group }}
     - mode: 644
+    - template: jinja
     - source:
       - salt://users/files/profile/{{ name }}/profile
       - salt://users/files/profile/profile

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,6 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -35,6 +37,12 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
+    {% if user_files_file_mode -%}
+    - file_mode: {{ user_files_file_mode }}
+    {% endif -%}
+    {% if user_files_sym_mode -%}
+    - sym_mode: {{ user_files_sym_mode }}
+    {% endif -%}
     - include_empty: True
     - keep_symlinks: True
     - require:

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,7 +9,7 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set template = salt['pillar.get'](('users:' ~ username ~ ':template'), None) -%}
+{%- set template = salt['pillar.get'](('users:' ~ username ~ ':user_files:template'), None) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,6 +9,7 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
+{%- set template = salt['pillar.get'](('users:' ~ username ~ ':template'), None) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -34,6 +35,7 @@ users_userfiles_{{ username }}_recursive:
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}
+    - template: {{ template }}
     - clean: False
     - include_empty: True
     - keep_symlinks: True

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,7 +9,7 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set template = salt['pillar.get'](('users:' ~ username ~ ':user_files:template'), None) -%}
+{%- set user_files_template = salt['pillar.get'](('users:' ~ username ~ ':user_files:template'), None) -%}
 {%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
 {%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
 {%- if user_files.enabled -%}
@@ -37,8 +37,8 @@ users_userfiles_{{ username }}_recursive:
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}
-    {%- if template is not None -%}
-    - template: {{ template }}
+    {%- if user_files_template is not None -%}
+    - template: {{ user_files_template }}
     {%- endif -%}
     - clean: False
     {% if user_files_file_mode -%}

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,8 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
-{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), None) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), None) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -37,10 +37,10 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
-    {% if user_files_file_mode -%}
+    {% if user_files_file_mode is not None -%}
     - file_mode: {{ user_files_file_mode }}
     {% endif -%}
-    {% if user_files_sym_mode -%}
+    {% if user_files_sym_mode is not None -%}
     - sym_mode: {{ user_files_sym_mode }}
     {% endif -%}
     - include_empty: True

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -35,7 +35,9 @@ users_userfiles_{{ username }}_recursive:
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}
+    {%- if template is not None -%}
     - template: {{ template }}
+    {%- endif -%}
     - clean: False
     - include_empty: True
     - keep_symlinks: True

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,8 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), None) -%}
-{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), None) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -37,10 +37,10 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
-    {% if user_files_file_mode is not None -%}
+    {% if user_files_file_mode -%}
     - file_mode: {{ user_files_file_mode }}
     {% endif -%}
-    {% if user_files_sym_mode is not None -%}
+    {% if user_files_sym_mode -%}
     - sym_mode: {{ user_files_sym_mode }}
     {% endif -%}
     - include_empty: True

--- a/users/vimrc.sls
+++ b/users/vimrc.sls
@@ -22,7 +22,8 @@ users_{{ name }}_user_vimrc:
     - user: {{ name }}
     - group: {{ user_group }}
     - mode: 644
-    - source: 
+    - template: jinja
+    - source:
       - salt://users/files/vimrc/{{ name }}/vimrc
       - salt://users/files/vimrc/vimrc
 {% endif %}


### PR DESCRIPTION
Dependency for https://github.com/heap/infrastructure/pull/426
Changes to add dotfiles to all accounts means that 'heap' account is processed in a way that does not execute templating yet, which leaves '.bashrc' with an un-substituted parameter in it